### PR TITLE
Upgrade the dependency on Bouncy Castle (1.46 -> 1.49)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <assembly.javadoc.dir>/usr/share/javadoc/${project.name}</assembly.javadoc.dir>
     <junitVersion>4.10</junitVersion>
     <canlVersion>1.1.0</canlVersion>
-    <bcVersion>1.46</bcVersion>
+    <bcVersion>1.49</bcVersion>
     <licensePluginVersion>1.9.0</licensePluginVersion>
     <releasePluginVersion>2.2.2</releasePluginVersion>
     <coberturaPluginVersion>2.5.2</coberturaPluginVersion>
@@ -191,7 +191,7 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcmail-jdk16</artifactId>
+      <artifactId>bcpkix-jdk15on</artifactId>
       <version>${bcVersion}</version>
     </dependency>
 

--- a/src/main/java/org/italiangrid/voms/ac/impl/DefaultVOMSValidationStrategy.java
+++ b/src/main/java/org/italiangrid/voms/ac/impl/DefaultVOMSValidationStrategy.java
@@ -39,6 +39,7 @@ import java.util.List;
 import javax.security.auth.x500.X500Principal;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.X509Extension;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
@@ -215,7 +216,7 @@ public class DefaultVOMSValidationStrategy implements VOMSACValidationStrategy{
 	
 	private boolean checkNoRevAvailExtension(VOMSAttribute attributes, List<VOMSValidationErrorMessage> validationErrors){
 		
-		X509Extension noRevAvail = attributes.getVOMSAC().getExtension(X509Extension.noRevAvail);
+		Extension noRevAvail = attributes.getVOMSAC().getExtension(X509Extension.noRevAvail);
 		if (noRevAvail != null && noRevAvail.isCritical()){
 			validationErrors.add(newErrorMessage(other, "NoRevAvail AC extension cannot be critical!"));
 			return false;
@@ -225,7 +226,7 @@ public class DefaultVOMSValidationStrategy implements VOMSACValidationStrategy{
 	
 	private boolean checkAuthorityKeyIdentifierExtension(VOMSAttribute attributes, List<VOMSValidationErrorMessage> validationErrors){
 		
-		X509Extension authKeyId = attributes.getVOMSAC().getExtension(X509Extension.authorityKeyIdentifier);
+		Extension authKeyId = attributes.getVOMSAC().getExtension(X509Extension.authorityKeyIdentifier);
 		if (authKeyId != null && authKeyId.isCritical()){
 			validationErrors.add(newErrorMessage(other, "AuthorityKeyIdentifier AC extension cannot be critical!"));
 			return false;

--- a/src/main/java/org/italiangrid/voms/asn1/VOMSACUtils.java
+++ b/src/main/java/org/italiangrid/voms/asn1/VOMSACUtils.java
@@ -39,6 +39,7 @@ import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x509.Attribute;
 import org.bouncycastle.asn1.x509.AttributeCertificate;
+import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.IetfAttrSyntax;
 import org.bouncycastle.asn1.x509.Target;
@@ -159,7 +160,7 @@ public class VOMSACUtils implements VOMSConstants{
 	private static List<String> deserializeACTargets(X509AttributeCertificateHolder ac){
 		List<String> targets = new ArrayList<String>();
 		
-		X509Extension targetExtension = ac.getExtension(X509Extension.targetInformation);
+		Extension targetExtension = ac.getExtension(X509Extension.targetInformation);
 		
 		if (targetExtension == null)
 			return targets;
@@ -306,7 +307,7 @@ public class VOMSACUtils implements VOMSConstants{
 		
 		List<VOMSGenericAttribute> gas = new ArrayList<VOMSGenericAttribute>();
 		
-		X509Extension gasExtension = ac.getExtension(VOMS_GENERIC_ATTRS_OID);
+		Extension gasExtension = ac.getExtension(VOMS_GENERIC_ATTRS_OID);
 		
 		if (gasExtension == null)
 			return gas;
@@ -364,7 +365,7 @@ public class VOMSACUtils implements VOMSConstants{
 	private static X509Certificate[] deserializeACCerts(X509AttributeCertificateHolder ac){
 		List<X509Certificate> certs = new ArrayList<X509Certificate>();
 		
-		X509Extension e = ac.getExtension(VOMS_CERTS_OID);
+		Extension e = ac.getExtension(VOMS_CERTS_OID);
 		
 		if (e == null)
 			return null;


### PR DESCRIPTION
Hi,

Could you please update the dependency on Bouncy Castle ? The new versions of Bouncy Castle do not preserve the binary compatibility and this is causing issues when components using different versions of Bouncy Castle are mixed together. This pull request updates the dependency to the latest release of Bouncy Castle.

Thank you.
