### PR TITLE
Do nothing on Windows instead of exception due to 'ls' and 'chmod' not found

### DIFF
--- a/src/main/java/org/italiangrid/voms/util/FilePermissionHelper.java
+++ b/src/main/java/org/italiangrid/voms/util/FilePermissionHelper.java
@@ -33,6 +33,7 @@ import org.italiangrid.voms.credential.FilePermissionError;
  */
 public class FilePermissionHelper {
 
+  private static final boolean s_isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows");
   public static enum PosixFilePermission {
 
     USER_RO("400", "-r--------"),
@@ -167,6 +168,9 @@ public class FilePermissionHelper {
 
     filenameSanityChecks(filename);
 
+    if (s_isWindows)
+      return;
+    
     if (p == null)
       throw new NullPointerException("null permission passed as argument");
 
@@ -249,6 +253,9 @@ public class FilePermissionHelper {
   public static void setFilePermissions(String filename,
     PosixFilePermission perm) {
 
+    if (s_isWindows)
+      return;
+    
     String cmd = String.format(CHMOD_CMD_TEMPLATE, perm.chmodForm(), filename);
 
     ProcessBuilder pb = new ProcessBuilder(cmd.split(" "));


### PR DESCRIPTION
Helps to not fail under Windows. Files permissions are not checked nor set (the Globus way of doing)
