### PR TITLE
Fix javadoc warnings/errors

### DIFF
--- a/src/main/java/org/italiangrid/voms/VOMSAttribute.java
+++ b/src/main/java/org/italiangrid/voms/VOMSAttribute.java
@@ -117,7 +117,7 @@ public interface VOMSAttribute {
    * This method checks whether the attributes are valid in a given time passed
    * as argument. No validation is performed on the attributes.
    * 
-   * @param time
+   * @param time time
    * @return <code>true</code> if valid, <code>false</code> otherwise
    */
   public boolean validAt(Date time);

--- a/src/main/java/org/italiangrid/voms/ac/VOMSACLookupStrategy.java
+++ b/src/main/java/org/italiangrid/voms/ac/VOMSACLookupStrategy.java
@@ -32,6 +32,7 @@ public interface VOMSACLookupStrategy {
    * This method defines how a set of VOMS Attribute Certificates is looked for
    * in a certificate chain.
    * 
+   * @param certChain certificate chain
    * @return a {@link List} of {@link ACParsingContext} that describes the
    *         lookup outcome
    */

--- a/src/main/java/org/italiangrid/voms/ac/VOMSACValidator.java
+++ b/src/main/java/org/italiangrid/voms/ac/VOMSACValidator.java
@@ -63,7 +63,7 @@ public interface VOMSACValidator extends VOMSACParser {
    * about validation without relying on the registration of a
    * {@link ValidationResultListener}.
    * 
-   * @param validatedChain
+   * @param validatedChain validated chain
    * @return a possibly empty list of {@link VOMSValidationResult} object
    *         providing access to validation results and related attributes
    */

--- a/src/main/java/org/italiangrid/voms/ac/VOMSAttributesNormalizationStrategy.java
+++ b/src/main/java/org/italiangrid/voms/ac/VOMSAttributesNormalizationStrategy.java
@@ -35,7 +35,7 @@ public interface VOMSAttributesNormalizationStrategy {
    * Returns the normalized view of VOMS Authorization information starting from
    * a list of VOMS Attribute certificates.
    * 
-   * @param acs
+   * @param acs a list of VOMS Attribute certificates
    * @return a possibly empty list {@link VOMSAttribute} object
    */
   public List<VOMSAttribute> normalizeAttributes(List<ACParsingContext> acs);

--- a/src/main/java/org/italiangrid/voms/ac/VOMSValidationResult.java
+++ b/src/main/java/org/italiangrid/voms/ac/VOMSValidationResult.java
@@ -43,7 +43,7 @@ public class VOMSValidationResult {
    * Default constructor.
    * 
    * @param attributes
-   *          the attributes this validation result refer to
+   *          the attributes this validation result refers to
    * @param valid
    *          <code>true</code> in case of validation success,
    *          <code>false</code> otherwise
@@ -56,6 +56,8 @@ public class VOMSValidationResult {
   /**
    * This constructor is used to pass in a list of validation errors as well.
    * 
+   * @param attributes
+   *          the attributes this validation result refers to
    * @param valid
    *          <code>true</code> in case of validation success,
    *          <code>false</code> otherwise

--- a/src/main/java/org/italiangrid/voms/asn1/VOMSACUtils.java
+++ b/src/main/java/org/italiangrid/voms/asn1/VOMSACUtils.java
@@ -82,10 +82,10 @@ public class VOMSACUtils implements VOMSConstants {
    * Deserializes the VOMS Attribute certificates in a given certificate
    * extension
    * 
-   * @param vomsExtension
+   * @param vomsExtension VOMS extension
    * @return the possybly empty {@link List} of {@link AttributeCertificate}
    *         extracted from a given extension
-   * @throws IOException
+   * @throws IOException IO exception
    */
   public static List<AttributeCertificate> getACsFromVOMSExtension(
     byte[] vomsExtension) throws IOException {
@@ -141,7 +141,7 @@ public class VOMSACUtils implements VOMSConstants {
    *          the {@link X509Certificate} where the ACs will be searched
    * @return the possibly empty {@link List} of {@link AttributeCertificate}
    *         objects extracted from the VOMS extension
-   * @throws IOException
+   * @throws IOException IO exception
    */
   public static List<AttributeCertificate> getACsFromCertificate(
     X509Certificate cert) throws IOException {

--- a/src/main/java/org/italiangrid/voms/credential/LoadCredentialsEventListener.java
+++ b/src/main/java/org/italiangrid/voms/credential/LoadCredentialsEventListener.java
@@ -25,10 +25,11 @@ package org.italiangrid.voms.credential;
 public interface LoadCredentialsEventListener {
 
   /**
-   * Informs that credentials are been looked for in the locations passed as
+   * Informs that credentials have been looked for in the locations passed as
    * argument.
    * 
    * @param locations
+   *          the locations where the credentials have been looked for
    */
   public void notifyCredentialLookup(String... locations);
 
@@ -37,6 +38,7 @@ public interface LoadCredentialsEventListener {
    * passed as argument.
    * 
    * @param locations
+   *          the locations where the credentials have been loaded from
    */
   public void notifyLoadCredentialSuccess(String... locations);
 
@@ -48,7 +50,7 @@ public interface LoadCredentialsEventListener {
    *          the {@link Throwable} that caused the credential load operation to
    *          fail
    * @param locations
-   *          the locations where the credentials where loaded from
+   *          the locations where the credentials were loaded from
    */
   public void notifyLoadCredentialFailure(Throwable error, String... locations);
 }

--- a/src/main/java/org/italiangrid/voms/examples/ValidationExample.java
+++ b/src/main/java/org/italiangrid/voms/examples/ValidationExample.java
@@ -58,11 +58,11 @@ public class ValidationExample {
   }
 
   /**
-   * @param args
-   * @throws IOException
-   * @throws FileNotFoundException
-   * @throws CertificateException
-   * @throws KeyStoreException
+   * @param args arguments
+   * @throws KeyStoreException key store exception
+   * @throws CertificateException certificate exception
+   * @throws FileNotFoundException file not found exception
+   * @throws IOException IO exception
    */
   public static void main(String[] args) throws KeyStoreException,
     CertificateException, FileNotFoundException, IOException {

--- a/src/main/java/org/italiangrid/voms/request/impl/AbstractVOMSProtocol.java
+++ b/src/main/java/org/italiangrid/voms/request/impl/AbstractVOMSProtocol.java
@@ -164,7 +164,7 @@ public abstract class AbstractVOMSProtocol implements VOMSProtocol {
   /**
    * Sets whether this protocol will skip SSL hostname checks
    * 
-   * @param skipHostnameChecks 
+   * @param skipHostnameChecks skip hostname checks
    */
   public void setSkipHostnameChecks(boolean skipHostnameChecks) {
   

--- a/src/main/java/org/italiangrid/voms/request/impl/DefaultVOMSACService.java
+++ b/src/main/java/org/italiangrid/voms/request/impl/DefaultVOMSACService.java
@@ -513,7 +513,7 @@ public class DefaultVOMSACService implements VOMSACService {
      * Sets the http protocol implementation
      * 
      * @param httpProtocol
-     *          the http protocol implementatino
+     *          the http protocol implementatioh
      * @return this {@link Builder} instance
      */
     public Builder httpProtocol(VOMSProtocol httpProtocol) {
@@ -524,6 +524,10 @@ public class DefaultVOMSACService implements VOMSACService {
 
     /**
      * Sets the legacy protocol implementation
+     * 
+     * @param legacyProtocol
+     *          the legacy protocol implementatioh
+     * @return this {@link Builder} instance
      */
     public Builder legacyProtocol(VOMSProtocol legacyProtocol) {
 

--- a/src/main/java/org/italiangrid/voms/request/impl/LegacyRequestSender.java
+++ b/src/main/java/org/italiangrid/voms/request/impl/LegacyRequestSender.java
@@ -97,6 +97,8 @@ public class LegacyRequestSender {
    * 
    * @param acRequest
    *          the AC request parameters. See {@link VOMSACRequest}.
+   * @param endpoint
+   *          VOMS server endpoint
    * @param stream
    *          an output stream.
    */

--- a/src/main/java/org/italiangrid/voms/request/impl/LegacyVOMSResponse.java
+++ b/src/main/java/org/italiangrid/voms/request/impl/LegacyVOMSResponse.java
@@ -37,7 +37,7 @@ public class LegacyVOMSResponse implements VOMSResponse {
    * Builds a VOMSResponse starting from a DOM an XML document (see
    * {@link Document}).
    * 
-   * @param res
+   * @param res XML response
    */
   public LegacyVOMSResponse(Document res) {
 

--- a/src/main/java/org/italiangrid/voms/store/LSCInfo.java
+++ b/src/main/java/org/italiangrid/voms/store/LSCInfo.java
@@ -60,8 +60,8 @@ public interface LSCInfo {
    * and hostname.
    * 
    * The certificate chain description is a list of X.500 distinguished names
-   * encoded as strings according to the OpenSSL slash-separated format, as in:
-   * <verbatim> /C=IT/O=INFN/CN=INFN CA </verbatim>
+   * encoded as strings according to the OpenSSL slash-separated format, as
+   * in: @verbatim /C=IT/O=INFN/CN=INFN CA @endverbatim
    * 
    * The first element in the description is the leaf certificate, while the
    * last is the CA certificate.
@@ -75,7 +75,7 @@ public interface LSCInfo {
    * Checks if the certificate chain description maintained in the LSC
    * information matches the certificate chain passed as argument.
    * 
-   * @param certChain
+   * @param certChain certificate chain
    * @return <code>true</code> if the description matches, <code>false</code>
    *         otherwise
    */

--- a/src/main/java/org/italiangrid/voms/store/impl/DefaultVOMSTrustStore.java
+++ b/src/main/java/org/italiangrid/voms/store/impl/DefaultVOMSTrustStore.java
@@ -106,6 +106,8 @@ public class DefaultVOMSTrustStore implements VOMSTrustStore {
   /**
    * Builds a list of trusted directories containing only
    * {@link #DEFAULT_VOMS_DIR}.
+   *
+   * @return list of trusted directories
    **/
   protected static List<String> buildDefaultTrustedDirs() {
 
@@ -118,6 +120,8 @@ public class DefaultVOMSTrustStore implements VOMSTrustStore {
    * 
    * @param localTrustDirs
    *          a non-null list of local trust directories
+   * @param listener
+   *          trust store status listener
    * @throws IllegalArgumentException
    *           when the list passed as argument is null
    */

--- a/src/main/java/org/italiangrid/voms/store/impl/VOMSThread.java
+++ b/src/main/java/org/italiangrid/voms/store/impl/VOMSThread.java
@@ -32,6 +32,8 @@ public class VOMSThread extends Thread {
    *          the object whose <code>run</code> method is called.
    * @param name
    *          the name of the new thread.
+   * @param handler
+   *          uncaught exception handler
    */
   public VOMSThread(Runnable target, String name,
     UncaughtExceptionHandler handler) {

--- a/src/main/java/org/italiangrid/voms/util/CachingCertificateValidator.java
+++ b/src/main/java/org/italiangrid/voms/util/CachingCertificateValidator.java
@@ -132,7 +132,7 @@ public class CachingCertificateValidator implements X509CertChainValidatorExt {
    * Validates a certificate chain using the wrapped validator, caching the
    * result for future validation calls.
    *
-   * @param certChain
+   * @param certChain certificate chain
    * @return a possibly cached {@link ValidationResult}
    * @see eu.emi.security.authn.x509.X509CertChainValidator#validate(java.security.cert.X509Certificate[])
    */
@@ -187,7 +187,7 @@ public class CachingCertificateValidator implements X509CertChainValidatorExt {
   }
 
   /**
-   * @param certPath
+   * @param certPath certificate path
    * @return the {@link ValidationResult}
    * @see eu.emi.security.authn.x509.X509CertChainValidator#validate(java.security.cert.CertPath)
    */
@@ -215,7 +215,7 @@ public class CachingCertificateValidator implements X509CertChainValidatorExt {
   }
 
   /**
-   * @param listener
+   * @param listener validation listener
    * @see eu.emi.security.authn.x509.X509CertChainValidator#addValidationListener(eu.emi.security.authn.x509.ValidationErrorListener)
    */
   public void addValidationListener(ValidationErrorListener listener) {
@@ -224,7 +224,7 @@ public class CachingCertificateValidator implements X509CertChainValidatorExt {
   }
 
   /**
-   * @param listener
+   * @param listener validation listener
    * @see eu.emi.security.authn.x509.X509CertChainValidator#removeValidationListener(eu.emi.security.authn.x509.ValidationErrorListener)
    */
   public void removeValidationListener(ValidationErrorListener listener) {
@@ -233,7 +233,7 @@ public class CachingCertificateValidator implements X509CertChainValidatorExt {
   }
 
   /**
-   * @param listener
+   * @param listener validation listener
    * @see eu.emi.security.authn.x509.X509CertChainValidator#addUpdateListener(eu.emi.security.authn.x509.StoreUpdateListener)
    */
   public void addUpdateListener(StoreUpdateListener listener) {
@@ -242,7 +242,7 @@ public class CachingCertificateValidator implements X509CertChainValidatorExt {
   }
 
   /**
-   * @param listener
+   * @param listener validation listener
    * @see eu.emi.security.authn.x509.X509CertChainValidator#removeUpdateListener(eu.emi.security.authn.x509.StoreUpdateListener)
    */
   public void removeUpdateListener(StoreUpdateListener listener) {

--- a/src/main/java/org/italiangrid/voms/util/CertificateValidatorBuilder.java
+++ b/src/main/java/org/italiangrid/voms/util/CertificateValidatorBuilder.java
@@ -142,7 +142,7 @@ public class CertificateValidatorBuilder {
   /**
    * Sets whether the created validator will be lazy in loading anchors
    * 
-   * @param lazyness
+   * @param lazyness lazyness
    * @return the builder object
    */
   public CertificateValidatorBuilder lazyAnchorsLoading(boolean lazyness) {
@@ -227,6 +227,9 @@ public class CertificateValidatorBuilder {
    * @param validationErrorListener
    *          the listener that will receive notification about validation
    *          errors
+   * @param storeUpdateListener
+   *          the listener that will receive notification about trust
+   *          anchor store updates
    * @param updateInterval
    *          the trust anchor store update interval
    * @param namespaceChecks
@@ -259,6 +262,9 @@ public class CertificateValidatorBuilder {
    * @param validationErrorListener
    *          the listener that will receive notification about validation
    *          errors
+   * @param storeUpdateListener
+   *          the listener that will receive notification about trust
+   *          anchor store updates
    * @param updateInterval
    *          the trust anchor store update interval
    * @param namespaceChecks

--- a/src/main/java/org/italiangrid/voms/util/CredentialsUtils.java
+++ b/src/main/java/org/italiangrid/voms/util/CredentialsUtils.java
@@ -62,11 +62,11 @@ public class CredentialsUtils {
   /**
    * Serializes a private key to an output stream according to an encoding.
    * 
-   * @param os
-   * @param key
-   * @param encoding
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @param os output stream
+   * @param key private key
+   * @param encoding private key encoding
+   * @throws IllegalArgumentException illegal argument exception
+   * @throws IOException IO exception
    */
   public static void savePrivateKey(OutputStream os, PrivateKey key,
     PrivateKeyEncoding encoding) throws IllegalArgumentException, IOException {
@@ -90,10 +90,10 @@ public class CredentialsUtils {
    * This method just delegates to canl, but provides a much more understandable
    * signature.
    * 
-   * @param os
-   * @param key
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @param os output stream
+   * @param key private key
+   * @throws IllegalArgumentException illegal argument exception
+   * @throws IOException IO exception
    */
   private static void savePrivateKeyPKCS8(OutputStream os, PrivateKey key)
     throws IllegalArgumentException, IOException {
@@ -108,10 +108,10 @@ public class CredentialsUtils {
    * This method just delegates to canl, but provides a much more understandable
    * signature.
    * 
-   * @param os
-   * @param key
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @param os output stream
+   * @param key provate key
+   * @throws IllegalArgumentException illegal argument exception
+   * @throws IOException IO exception
    */
   private static void savePrivateKeyPKCS1(OutputStream os, PrivateKey key)
     throws IllegalArgumentException, IOException {
@@ -125,16 +125,16 @@ public class CredentialsUtils {
    * Saves user credentials as a plain text PEM data. <br>
    * Writes the user certificate chain first, then the user key.
    * 
-   * @param os
-   * @param uc
-   * @param encoding
-   * @throws UnrecoverableKeyException
-   * @throws KeyStoreException
-   * @throws IllegalArgumentException
-   * @throws NoSuchAlgorithmException
-   * @throws IOException
-   * @throws NoSuchProviderException
-   * @throws CertificateException
+   * @param os output stream
+   * @param uc user credential
+   * @param encoding private key encoding
+   * @throws UnrecoverableKeyException unrecoverable key exception
+   * @throws KeyStoreException key store exception
+   * @throws IllegalArgumentException illegal argument exception
+   * @throws NoSuchAlgorithmException no such algorithm exception
+   * @throws IOException IO exception
+   * @throws NoSuchProviderException no such provider exception
+   * @throws CertificateException certificate exception
    */
   public static void saveProxyCredentials(OutputStream os, X509Credential uc,
     PrivateKeyEncoding encoding) throws UnrecoverableKeyException,
@@ -174,15 +174,15 @@ public class CredentialsUtils {
    * Writes the user certificate chain first, then the user key, using the
    * default encoding specified in {@link #DEFAULT_ENCONDING}.
    *
-   * @param os
-   * @param uc
-   * @throws UnrecoverableKeyException
-   * @throws KeyStoreException
-   * @throws IllegalArgumentException
-   * @throws NoSuchAlgorithmException
-   * @throws IOException
-   * @throws NoSuchProviderException
-   * @throws CertificateException
+   * @param os output stream
+   * @param uc user credendial
+   * @throws UnrecoverableKeyException unrecoverable key exception
+   * @throws KeyStoreException key store exception
+   * @throws IllegalArgumentException illegal argument exception
+   * @throws NoSuchAlgorithmException no such algorithm exception
+   * @throws IOException IO exception
+   * @throws NoSuchProviderException no such provider exception
+   * @throws CertificateException certificate exception
    */
   public static void saveProxyCredentials(OutputStream os, X509Credential uc)
     throws UnrecoverableKeyException, KeyStoreException,
@@ -202,13 +202,13 @@ public class CredentialsUtils {
    *          the credential to be saved
    * @param encoding
    *          the private key encoding
-   * @throws IOException
-   * @throws UnrecoverableKeyException
-   * @throws KeyStoreException
-   * @throws IllegalArgumentException
-   * @throws NoSuchAlgorithmException
-   * @throws NoSuchProviderException
-   * @throws CertificateException
+   * @throws IOException IOException
+   * @throws UnrecoverableKeyException unrecoverable key exception
+   * @throws KeyStoreException key store exception
+   * @throws IllegalArgumentException illegal argument exception
+   * @throws NoSuchAlgorithmException no such algorithm exception
+   * @throws NoSuchProviderException no such provider exception
+   * @throws CertificateException certificate exception
    */
   public static void saveProxyCredentials(String proxyFileName,
     X509Credential uc, PrivateKeyEncoding encoding) throws IOException,
@@ -238,14 +238,16 @@ public class CredentialsUtils {
    * encoding specified in {@link #DEFAULT_ENCONDING}.
    * 
    * @param proxyFileName
+   *          the file where the proxy will be saved
    * @param uc
-   * @throws UnrecoverableKeyException
-   * @throws KeyStoreException
-   * @throws IllegalArgumentException
-   * @throws NoSuchAlgorithmException
-   * @throws NoSuchProviderException
-   * @throws CertificateException
-   * @throws IOException
+   *          the credential to be saved
+   * @throws UnrecoverableKeyException unrecoverable key exception
+   * @throws KeyStoreException key store exception
+   * @throws IllegalArgumentException illegal argument exception
+   * @throws NoSuchAlgorithmException no such algorithm exception
+   * @throws NoSuchProviderException no such provider exception
+   * @throws CertificateException certificate exception
+   * @throws IOException IOException
    */
   public static void saveProxyCredentials(String proxyFileName,
     X509Credential uc) throws UnrecoverableKeyException, KeyStoreException,

--- a/src/main/java/org/italiangrid/voms/util/VOMSFQANNamingScheme.java
+++ b/src/main/java/org/italiangrid/voms/util/VOMSFQANNamingScheme.java
@@ -96,7 +96,7 @@ public class VOMSFQANNamingScheme {
    * syntax used by voms to identify roles.
    * 
    * 
-   * @param roleName
+   * @param roleName role name
    * @throws VOMSError
    *           If the string passed as argument doens not comply with the voms
    *           sytax.


### PR DESCRIPTION
Java 8's javadoc is much more strict, and javadoc problems now gives errors instead of warnings, which causes the build to fail. This is an attempt to fix the build.

In this patch many of the javadoc comments are quite minimalistic and don't really provide proper documentation. Someone more familiar with the code can certainly improve them. But these changes made it pass the compilation.
