### PR TITLE
Add source version to javadoc configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${plugin.javadoc.version}</version>
         <configuration>
+          <source>1.8</source>
           <outputDirectory>${project.build.directory}/javadoc</outputDirectory>
           <reportOutputDirectory>${project.reporting.outputDirectory}/javadoc</reportOutputDirectory>
         </configuration>


### PR DESCRIPTION
This fixes build failure with OpenJDK 11:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.1:jar (attach-javadocs) on project voms-api-java: MavenReportException: Error while generating Javadoc: 
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
[ERROR] 
[ERROR] Command line was: /usr/lib/jvm/java-11-openjdk-amd64/bin/javadoc @options @packages
```
