### PR TITLE
Remove Guava library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
     <mockito.version>1.9.5</mockito.version>
     <jcip.version>1.0</jcip.version>
     <bc.version>1.58</bc.version>
-    <guava.version>33.1.0-jre</guava.version>
 
     <!-- properties -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -262,12 +261,6 @@
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
         <version>${bc.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/italiangrid/voms/util/CredentialsUtils.java
+++ b/src/main/java/org/italiangrid/voms/util/CredentialsUtils.java
@@ -35,9 +35,9 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
-
-import com.google.common.collect.Sets;
 
 import eu.emi.security.authn.x509.X509Credential;
 import eu.emi.security.authn.x509.helpers.CertificateHelpers;
@@ -227,7 +227,8 @@ public class CredentialsUtils {
     final Path proxyFilePath = Paths.get(proxyFileName);
     final FileAttribute<Set<PosixFilePermission>> permissions =
         PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------"));
-    final Set<StandardOpenOption> options = Sets.newHashSet(CREATE_NEW, WRITE);
+    final Set<StandardOpenOption> options = new HashSet<>();
+    Collections.addAll(options, CREATE_NEW, WRITE);
 
     try {
       Files.delete(proxyFilePath);


### PR DESCRIPTION
The Guava documentation says that the newHashSet method is not actually very useful and will likely be deprecated in the future