### PR TITLE
Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,13 +33,13 @@ SPDX-License-Identifier: Apache-2.0
   <properties>
 
     <!-- versions -->
-    <plugin.enforcer.version>3.5.0</plugin.enforcer.version>
+    <plugin.enforcer.version>3.6.2</plugin.enforcer.version>
     <plugin.versions.version>2.16.1</plugin.versions.version>
     <plugin.compiler.version>3.13.0</plugin.compiler.version>
-    <plugin.release.version>3.1.1</plugin.release.version>
+    <plugin.release.version>3.3.1</plugin.release.version>
     <plugin.source.version>2.2.1</plugin.source.version>
     <plugin.assembly.version>3.7.1</plugin.assembly.version>
-    <plugin.jar.version>3.4.2</plugin.jar.version>
+    <plugin.jar.version>3.5.0</plugin.jar.version>
     <plugin.javadoc.version>2.9.1</plugin.javadoc.version>
     <plugin.cobertura.version>2.7</plugin.cobertura.version>
     <plugin.gpg.version>3.2.5</plugin.gpg.version>
@@ -48,9 +48,9 @@ SPDX-License-Identifier: Apache-2.0
     <plugin.javadoc.version>3.11.2</plugin.javadoc.version>
 
     <junit.version>4.13.2</junit.version>
-    <hamcrest.version>1.3</hamcrest.version>
+    <hamcrest.version>3.0</hamcrest.version>
     <canl.version>2.8.3</canl.version>
-    <mockito.version>5.16.0</mockito.version>
+    <mockito.version>5.23.0</mockito.version>
     <jcip.version>1.0</jcip.version>
     <bc.version>1.84</bc.version>
 


### PR DESCRIPTION
* Bump org.apache.maven.plugins:maven-release-plugin from 3.1.1 to 3.3.1
* Bump org.mockito:mockito-core from 5.16.0 to 5.23.0
* Bump org.apache.maven.plugins:maven-jar-plugin from 3.4.2 to 3.5.0
* Bump org.apache.maven.plugins:maven-enforcer-plugin from 3.5.0 to 3.6.2
* Bump org.hamcrest:hamcrest-core from 1.3 to 3.0