### PR TITLE
Fix two warnings

### DIFF
--- a/src/main/java/org/italiangrid/voms/ac/impl/DefaultVOMSValidationStrategy.java
+++ b/src/main/java/org/italiangrid/voms/ac/impl/DefaultVOMSValidationStrategy.java
@@ -249,7 +249,8 @@ public class DefaultVOMSValidationStrategy implements VOMSACValidationStrategy {
       X509CertificateHolder aaCertHolder = new JcaX509CertificateHolder(aaCert);
 
       SubjectKeyIdentifier skid = SubjectKeyIdentifier.fromExtensions(aaCertHolder.getExtensions());
-      boolean authKeyIdMatches = Arrays.equals(skid.getKeyIdentifier(), akid.getKeyIdentifier());
+      boolean authKeyIdMatches =
+          Arrays.equals(skid.getKeyIdentifier(), akid.getKeyIdentifierOctets());
 
       if (!authKeyIdMatches) {
         validationErrors.add(

--- a/src/main/java/org/italiangrid/voms/request/impl/LegacyProtocol.java
+++ b/src/main/java/org/italiangrid/voms/request/impl/LegacyProtocol.java
@@ -18,15 +18,13 @@ import java.security.cert.X509Certificate;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import org.italiangrid.voms.request.VOMSACRequest;
-import org.italiangrid.voms.request.VOMSProtocol;
 import org.italiangrid.voms.request.VOMSProtocolError;
 import org.italiangrid.voms.request.VOMSProtocolListener;
 import org.italiangrid.voms.request.VOMSResponse;
 import org.italiangrid.voms.request.VOMSServerInfo;
 
 /** Protocol implementing the legacy interface. */
-public class LegacyProtocol extends AbstractVOMSProtocol
-    implements VOMSProtocol, HostnameMismatchCallback2 {
+public class LegacyProtocol extends AbstractVOMSProtocol implements HostnameMismatchCallback2 {
 
   public LegacyProtocol(
       X509CertChainValidatorExt validator,


### PR DESCRIPTION
getKeyIdentifier is deprecated use getKeyIdentifierOctets instead
Redundant superinterface VOMSProtocol for the type LegacyProtocol, already defined by AbstractVOMSProtocol